### PR TITLE
Adjust left margin

### DIFF
--- a/src/css/app.css
+++ b/src/css/app.css
@@ -97,10 +97,12 @@ ul li.not-found {
   height: 100%;
   width: auto;
   max-width: 100%;
+  padding: 10px;
 }
 
 .search-results ul li a p {
   margin-top: 2px;
+  margin-left: 110px;
 }
 
 

--- a/src/css/app.css
+++ b/src/css/app.css
@@ -70,6 +70,7 @@ a:visited {
 }
 
 .search-results ul {
+  max-width: 50em;
   list-style: none;
 }
 


### PR DESCRIPTION
Adjust CSS so that text does not flow under image in search results. Fix for issue #7 
