### PR TITLE
fix for stretched image on desktop

### DIFF
--- a/src/css/app.css
+++ b/src/css/app.css
@@ -113,6 +113,7 @@ header img {
   height: 100%;
   width: auto;
   max-height: 350px;
+  max-width: 100%;
 }
 
 header a {
@@ -182,7 +183,6 @@ input {
 
 @media (max-width: 600px) {
   header img {
-    max-width: 100%;
     height: auto;
   }
 }


### PR DESCRIPTION
Beware though: 
- I'm not certain which aspect ratio is correct. 
- Only tested in Safari.
