### PR TITLE
Don't reload markers on pan

### DIFF
--- a/src/js/map.js
+++ b/src/js/map.js
@@ -43,11 +43,7 @@ L.tileLayer('http://{s}.tile.openstreetmap.se/hydda/full/{z}/{x}/{y}.png', {
 
 var markers = L.markerClusterGroup();
 
-map.on('moveend', function() {
-  renderMarkers();
-});
-
-map.on('whenReady', function() {
+map.on('load', function() {
   renderMarkers();
 });
 


### PR DESCRIPTION
Issue #10 
Removed map.on moveend which clears and renders the markers every time the map is moved.
Changed map.on whenReady to load so that it will initialize the markers.
Tested in Chrome 54. You may want to check in your own browser.
