### PR TITLE
Adds reporting functionality for text from Bebyggelseregistret. Fix for #11

### DIFF
--- a/src/church.html
+++ b/src/church.html
@@ -32,7 +32,10 @@
 					<a id="church-wikipedia-link" href="#">Läs mer på Wikipedia</a>
 					<h2 id="bbr-heading">Bebyggelseregistret</h2>
 					<p id="church-bbr" class="expandable-p"></p>
+
 					<button id="bbr-expand">Expandera</button>
+					<a id="church-report" class="hidden" href="#">Anmärk<span class="entypo-edit"></span></a>
+
 					<h2>Läs mer</h2>
 					<a id="church-kringla" href="#" class="btn">I Kringla</a>
 					<a id="church-commons" href="#" class="btn">Commons</a>

--- a/src/church.html
+++ b/src/church.html
@@ -34,7 +34,7 @@
 					<p id="church-bbr" class="expandable-p"></p>
 
 					<button id="bbr-expand">Expandera</button>
-					<a id="church-report" class="hidden" href="#">Anmärk<span class="entypo-edit"></span></a>
+					<a id="church-report" class="hidden" href="#">Anmärk</a>
 
 					<h2>Läs mer</h2>
 					<a id="church-kringla" href="#" class="btn">I Kringla</a>

--- a/src/church.html
+++ b/src/church.html
@@ -30,9 +30,9 @@
 					<h1 id="church-title"></h1>
 					<p id="church-wikipedia"></p>
 					<a id="church-wikipedia-link" href="#">Läs mer på Wikipedia</a>
+
 					<h2 id="bbr-heading">Bebyggelseregistret</h2>
 					<p id="church-bbr" class="expandable-p"></p>
-
 					<button id="bbr-expand">Expandera</button>
 					<a id="church-report" class="hidden" href="#">Anmärk</a>
 

--- a/src/css/app.css
+++ b/src/css/app.css
@@ -173,6 +173,7 @@ input {
   background-color: #4B7740;
   color: #fff;
 }
+
 #church-report {
   float: right;
   margin-right:10px;

--- a/src/css/app.css
+++ b/src/css/app.css
@@ -1,3 +1,4 @@
+
 html * {
   -webkit-box-sizing: border-box;
   -moz-box-sizing: border-box;
@@ -171,6 +172,10 @@ input {
   padding-top: 0px;
   background-color: #4B7740;
   color: #fff;
+}
+#church-report {
+  float: right;
+  margin-right:10px;
 }
 
 @media (min-width: 600px) {

--- a/src/js/application.js
+++ b/src/js/application.js
@@ -61,6 +61,7 @@ var kyrksok = {
 
 var church = kyrksok.getUrlParameter('church');
 if (church) {
+  
   $('#loading-screen').css('display', 'block');
   kyrksok.renderChurch(church, function(data) {
     // if church is not found redirect
@@ -69,8 +70,12 @@ if (church) {
     }
 
     item = data.church[0];
+
+    var mailText = 'mailto:bebyggelseregistret@raa.se?subject=Angående ' + item.label + ' - via kyrksok.se&body=I kyrkan med id: ' + item.kulturarvsdata + ' har jag följande att anmärka: ';
+    
     document.title = 'Kyrksök - ' + item.label;
     $('#church-title').text(item.label);
+    $('#church-report').attr('href', mailText);
     $('#church-wikipedia').text(item.wp_description);
     $('#church-wikipedia-link').attr('href', kyrksok.wikipedia + item.wikipedia);
     $('#church-kringla').attr('href', kyrksok.kringla + item.kulturarvsdata);
@@ -106,10 +111,12 @@ $('#bbr-expand').click(function() {
   if (!bbrExpanded) {
     $('#church-bbr').css('height', '100%');
     $('#bbr-expand').text('Visa mindre');
+    $('#church-report').show();
     bbrExpanded = true;
   } else {
     $('#church-bbr').css('height', '54px');
     $('#bbr-expand').text('Expandera');
+    $('#church-report').hide();
     bbrExpanded = false;
   }
 });


### PR DESCRIPTION
Fix for #11 
Needs: 
- edit icon (using Entypo by the great Daniel Bruce). 
- testing in other browsers and devices

Caveat:
This opens up an e-mail with the content body as requested but without the "Mejlet har skapats från webbplatsen kyrksok.se" at the ending. Instead we append the subject line with " - via kyrksok.se", as I couldn't find a way to appen the content as requested.
